### PR TITLE
Add tarpaulin Dockerfile for consensource-api

### DIFF
--- a/docker/tarpaulin/consensource-api/Dockerfile
+++ b/docker/tarpaulin/consensource-api/Dockerfile
@@ -1,0 +1,27 @@
+FROM target/consensource-rust:1.39-nightly
+
+# Install zqm, protobuf, wget, cmake, netcat
+RUN apt-get update && \
+    apt-get install -y unzip libzmq3-dev protobuf-compiler wget cmake netcat && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean
+
+# Install protoc for protoc-rust crate (automate protobuf generation)
+RUN echo "Installing protoc..." && \
+    curl -OLsS https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip && \
+    yes | unzip protoc-3.6.1-linux-x86_64.zip -d protoc3 && \
+    rm protoc-3.6.1-linux-x86_64.zip
+
+# Set system protoc to protoc3 (defaults to protoc2)
+RUN mv protoc3/bin/* /usr/local/bin/ && \
+    mv protoc3/include/* /usr/local/include/ && \
+    rm -rf protoc3/
+
+# Use latest stable/nightly of rust toolchain & linter (rustfmt) & install tarpaulin
+RUN rustup default nightly && \
+    cargo install cargo-tarpaulin
+
+# Make a testing directory for tarpaulin
+RUN mkdir /tarpaulin && \
+    cd /tarpaulin
+    


### PR DESCRIPTION
Signed-off-by: AdeebAhmed <adeeb.ahmed@target.com>

## Proposed change/fix

First of a few dockerfiles that will be used by travisCI to run tarpaulin and collect code coverage metrics

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

```
docker pull target/consensource-api:tarpaulin
docker run -it target/consensource-api:tarpaulin bash

cd tarpaulin
cargo tarpaulin
```

You should get the error: ```Error: "Failed to parse Cargo.toml! Error: failed to read `/tarpaulin/Cargo.toml`"```

Just testing this image has tarpaulin on it, it also has all the dependencies for consensource. The idea is image can be reused across components. Just mount the component into /tarpaulin when running the container.