### PR TITLE
Update AssertAction to include existing Factory, Add Ingestion org type

### DIFF
--- a/common/src/addressing.rs
+++ b/common/src/addressing.rs
@@ -50,8 +50,8 @@ pub fn make_standard_address(standard_id: &str) -> String {
 }
 
 /// Returns the address for a assertion based on the provided assertion id
-pub fn make_assertion_address(standard_id: &str) -> String {
-    get_family_namespace_prefix() + RESERVED_SPACE + ASSERTION + &hash(standard_id, 60)
+pub fn make_assertion_address(assertion_id: &str) -> String {
+    get_family_namespace_prefix() + RESERVED_SPACE + ASSERTION + &hash(assertion_id, 60)
 }
 
 #[derive(Debug, PartialEq)]

--- a/protos/assertion.proto
+++ b/protos/assertion.proto
@@ -17,7 +17,7 @@ message Assertion {
     string assertor_pub_key = 2;
 
     //The type of the assertion object
-    Type type = 3;
+    Type assertion_type = 3;
 
     //The id of the record that is an assertion
     string object_id = 4;

--- a/protos/organization.proto
+++ b/protos/organization.proto
@@ -6,6 +6,7 @@ message Organization {
         CERTIFYING_BODY = 1;
         STANDARDS_BODY = 2;
         FACTORY = 3;
+        INGESTION = 4;
     }
 
     message Authorization {
@@ -102,6 +103,11 @@ message Factory {
 
     // Location of the factory
     Address address = 1;
+}
+
+message Ingestion {
+  // This message could be used to capture information that is only
+  // pertinent to an Ingestion service
 }
 
 message OrganizationContainer {

--- a/protos/payload.proto
+++ b/protos/payload.proto
@@ -198,11 +198,18 @@ message AccreditCertifyingBodyAction {
 }
 
 message AssertAction {
-
+    // UUID
+    string assertion_id = 1;
+    // Wrapper around CreateOrganizationAction.
+    // Support assertions about existing factories
+    message FactoryAssertion {
+      CreateOrganizationAction factory = 1;
+      string existing_factory_id = 2;
+    }
     // An AssertAction will be exactly one of these at a time.
     oneof assertion {
       // Asserts a new factory exists, or that an existing factory has different info.
-      CreateOrganizationAction new_factory = 2;
+      FactoryAssertion new_factory = 2;
 
       // Asserts a factory that is already in state has a certificate.
       IssueCertificateAction new_certificate = 3;


### PR DESCRIPTION
## Proposed change/fix

- Augment `AssertAction` message with an `assertion_id` and `existing_factory_id` if the factory assertion is about an existing factory.
- Add `RETAILER` as possible organization type

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test
`clip`
`cargo test`