### PR TITLE
Common library for making Transactions & Batches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,32 @@
 language: rust
 rust:
-    - 1.44.0
+  - 1.44.0
 
 before_install:
-    # Install protoc for protoc-rust crate (automate protobuf generation)
-    - curl -OLsS https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip
-    - unzip protoc-3.6.1-linux-x86_64.zip -d protoc3
-    - rm protoc-3.6.1-linux-x86_64.zip
-    # Set system protoc to protoc3 (defaults to protoc2)
-    - sudo mv protoc3/bin/* /usr/local/bin/
-    - sudo mv protoc3/include/* /usr/local/include/
-    - rm -rf protoc3/
-    # Install latest stable/nightly of rust toolchain & linter (rustfmt)
-    - cd common
-    - rustup component add rustfmt
-  
+  # Install ZMQ
+  - sudo apt-get update
+  - sudo apt-get install -y libzmq3-dev unzip protobuf-compiler
+  - sudo apt-get clean
+  # Install protoc for protoc-rust crate (automate protobuf generation)
+  - curl -OLsS https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip
+  - unzip protoc-3.6.1-linux-x86_64.zip -d protoc3
+  - rm protoc-3.6.1-linux-x86_64.zip
+  # Set system protoc to protoc3 (defaults to protoc2)
+  - sudo mv protoc3/bin/* /usr/local/bin/
+  - sudo mv protoc3/include/* /usr/local/include/
+  - rm -rf protoc3/
+  # Install latest stable/nightly of rust toolchain & linter (rustfmt)
+  - cd common
+  - rustup component add rustfmt
+
 before_script:
-    - echo $TRAVIS_COMMIT
-    - echo $TRAVIS_TAG
-    - echo $TRAVIS_BRANCH
-    - echo $TRAVIS_BUILD_NUMBER
-    - echo $TRAVIS_REPO_SLUG
+  - echo $TRAVIS_COMMIT
+  - echo $TRAVIS_TAG
+  - echo $TRAVIS_BRANCH
+  - echo $TRAVIS_BUILD_NUMBER
+  - echo $TRAVIS_REPO_SLUG
 
 script:
-    # Lint, build common
-    - cargo fmt -- --check
-    - cargo build
+  # Lint, build common
+  - cargo fmt -- --check
+  - cargo build

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Target"]
 
 [dependencies]
 protobuf = "2.17.0"
+sawtooth-sdk = "0.3"
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/common/src/action.rs
+++ b/common/src/action.rs
@@ -1,0 +1,268 @@
+use crypto::digest::Digest;
+use crypto::sha2::Sha256;
+use proto::certificate::Certificate_CertificateData;
+use proto::organization::Factory_Address;
+use proto::organization::Organization_Authorization_Role;
+use proto::organization::Organization_Contact;
+use proto::organization::Organization_Type;
+use proto::payload;
+use proto::payload::AssertAction_FactoryAssertion;
+use proto::payload::IssueCertificateAction_Source;
+use proto::request::Request_Status;
+
+/// Returns a payload for creating an Agent
+pub fn create_agent(name: &str, timestamp: u64) -> payload::CreateAgentAction {
+    let mut agent = payload::CreateAgentAction::new();
+    agent.set_name(String::from(name));
+    agent.set_timestamp(timestamp);
+    agent
+}
+
+/// Returns a payload for to authorize an Agent
+pub fn authorize_agent(
+    pub_key: &str,
+    role: Organization_Authorization_Role,
+) -> payload::AuthorizeAgentAction {
+    let mut agent = payload::AuthorizeAgentAction::new();
+    agent.set_public_key(String::from(pub_key));
+    agent.set_role(role);
+
+    agent
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn create_organization(
+    id: &str,
+    name: &str,
+    org_type: Organization_Type,
+    contact_name: &str,
+    contact_phone_number: &str,
+    contact_language_code: &str,
+    street: Option<&str>,
+    city: Option<&str>,
+    country: Option<&str>,
+) -> payload::CreateOrganizationAction {
+    let mut organization = payload::CreateOrganizationAction::new();
+    organization.set_name(String::from(name));
+    organization.set_id(String::from(id));
+    organization.set_organization_type(org_type);
+
+    if org_type == Organization_Type::FACTORY {
+        let mut factory_address = Factory_Address::new();
+        factory_address.set_street_line_1(street.unwrap().to_string());
+        factory_address.set_city(city.unwrap().to_string());
+        factory_address.set_country(country.unwrap().to_string());
+        organization.set_address(factory_address);
+    }
+
+    let mut contact = Organization_Contact::new();
+    contact.set_name(String::from(contact_name));
+    contact.set_phone_number(String::from(contact_phone_number));
+    contact.set_language_code(String::from(contact_language_code));
+    organization.set_contacts(protobuf::RepeatedField::from_vec(vec![contact]));
+
+    organization
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn update_organization(
+    id: &str,
+    name: Option<&str>,
+    contact_name: Option<&str>,
+    contact_phone_number: Option<&str>,
+    contact_language_code: Option<&str>,
+    street: Option<&str>,
+    city: Option<&str>,
+    country: Option<&str>,
+) -> payload::UpdateOrganizationAction {
+    let mut organization = payload::UpdateOrganizationAction::new();
+    organization.set_id(String::from(id));
+    if let Some(name) = name {
+        organization.set_name(String::from(name));
+    }
+
+    if let (Some(contact_name), Some(contact_phone_number), Some(contact_language_code)) =
+        (contact_name, contact_phone_number, contact_language_code)
+    {
+        let mut contact = Organization_Contact::new();
+        contact.set_name(String::from(contact_name));
+        contact.set_phone_number(String::from(contact_phone_number));
+        contact.set_language_code(String::from(contact_language_code));
+        organization.set_contacts(protobuf::RepeatedField::from_vec(vec![contact]));
+    };
+
+    if let (Some(street), Some(city), Some(country)) = (street, city, country) {
+        let mut factory_address = Factory_Address::new();
+        factory_address.set_street_line_1(street.to_string());
+        factory_address.set_city(city.to_string());
+        factory_address.set_country(country.to_string());
+        organization.set_address(factory_address);
+    }
+
+    organization
+}
+
+pub fn issue_certificate(
+    id: &str,
+    factory_id: &str,
+    request_id: Option<&str>,
+    standard_id: &str,
+    cert_data: Vec<Certificate_CertificateData>,
+    valid_from: &str,
+    valid_to: &str,
+) -> payload::IssueCertificateAction {
+    let mut certificate = payload::IssueCertificateAction::new();
+    certificate.set_id(id.to_string());
+    if let Some(request_id) = request_id {
+        certificate.set_request_id(request_id.to_string());
+        certificate.set_source(IssueCertificateAction_Source::FROM_REQUEST);
+    } else {
+        certificate.set_factory_id(factory_id.to_string());
+        certificate.set_standard_id(standard_id.to_string());
+        certificate.set_source(IssueCertificateAction_Source::INDEPENDENT);
+    }
+    certificate.set_certificate_data(::protobuf::RepeatedField::from_vec(cert_data));
+    certificate.set_valid_from(valid_from.parse().unwrap());
+    certificate.set_valid_to(valid_to.parse().unwrap());
+
+    certificate
+}
+
+pub fn update_certificate(
+    id: &str,
+    cert_data: Vec<Certificate_CertificateData>,
+    valid_from: &str,
+    valid_to: &str,
+) -> payload::UpdateCertificateAction {
+    let mut certificate = payload::UpdateCertificateAction::new();
+    certificate.set_id(id.to_string());
+    certificate.set_certificate_data(::protobuf::RepeatedField::from_vec(cert_data));
+    certificate.set_valid_from(valid_from.parse().unwrap());
+    certificate.set_valid_to(valid_to.parse().unwrap());
+
+    certificate
+}
+
+pub fn create_standard(
+    name: &str,
+    version: &str,
+    description: &str,
+    link: &str,
+    approval_date: u64,
+) -> payload::CreateStandardAction {
+    let mut standard = payload::CreateStandardAction::new();
+
+    let mut standard_id_sha = Sha256::new();
+    standard_id_sha.input_str(name);
+    standard.set_standard_id(standard_id_sha.result_str());
+    standard.set_name(String::from(name));
+    standard.set_version(String::from(version));
+    standard.set_description(String::from(description));
+    standard.set_link(String::from(link));
+    standard.set_approval_date(approval_date);
+
+    standard
+}
+
+pub fn update_standard(
+    name: &str,
+    version: &str,
+    description: &str,
+    link: &str,
+    approval_date: u64,
+) -> payload::UpdateStandardAction {
+    let mut standard = payload::UpdateStandardAction::new();
+
+    let mut standard_id_sha = Sha256::new();
+    standard_id_sha.input_str(name);
+    standard.set_standard_id(standard_id_sha.result_str());
+    standard.set_version(String::from(version));
+    standard.set_description(String::from(description));
+    standard.set_link(String::from(link));
+    standard.set_approval_date(approval_date);
+
+    standard
+}
+
+pub fn create_accreditation(
+    standard_id: &str,
+    certifying_body_id: &str,
+    valid_from: u64,
+    valid_to: u64,
+) -> payload::AccreditCertifyingBodyAction {
+    let mut accreditation = payload::AccreditCertifyingBodyAction::new();
+    accreditation.set_standard_id(String::from(standard_id));
+    accreditation.set_certifying_body_id(String::from(certifying_body_id));
+    accreditation.set_valid_from(valid_from);
+    accreditation.set_valid_to(valid_to);
+
+    accreditation
+}
+
+pub fn open_request(
+    request_id: &str,
+    standard_id: &str,
+    request_date: u64,
+) -> payload::OpenRequestAction {
+    let mut request = payload::OpenRequestAction::new();
+    request.set_id(String::from(request_id));
+    request.set_standard_id(String::from(standard_id));
+    request.set_request_date(request_date);
+
+    request
+}
+
+pub fn change_request_status(
+    request_id: &str,
+    status: Request_Status,
+) -> payload::ChangeRequestStatusAction {
+    let mut request = payload::ChangeRequestStatusAction::new();
+    request.set_request_id(String::from(request_id));
+    request.set_status(status);
+
+    request
+}
+
+pub fn create_factory_assertion(
+    assertion_id: &str,
+    create_organization_action_payload: payload::CreateOrganizationAction,
+) -> payload::AssertAction {
+    let mut assertion = payload::AssertAction::new();
+    assertion.set_assertion_id(String::from(assertion_id));
+
+    let mut factory_assertion = AssertAction_FactoryAssertion::new();
+    factory_assertion.set_factory(create_organization_action_payload);
+    assertion.set_new_factory(factory_assertion);
+
+    assertion
+}
+
+pub fn create_standard_assertion(
+    assertion_id: &str,
+    create_standard_action_payload: payload::CreateStandardAction,
+) -> payload::AssertAction {
+    let mut assertion = payload::AssertAction::new();
+    assertion.set_assertion_id(String::from(assertion_id));
+    assertion.set_new_standard(create_standard_action_payload);
+
+    assertion
+}
+
+pub fn create_certificate_assertion(
+    assertion_id: &str,
+    issue_certificate_action_payload: payload::IssueCertificateAction,
+) -> payload::AssertAction {
+    let mut assertion = payload::AssertAction::new();
+    assertion.set_assertion_id(String::from(assertion_id));
+    assertion.set_new_certificate(issue_certificate_action_payload);
+
+    assertion
+}
+
+pub fn transfer_assertion(assertion_id: &str) -> payload::TransferAssertionAction {
+    let mut transfer = payload::TransferAssertionAction::new();
+    transfer.set_assertion_id(String::from(assertion_id));
+    transfer.set_new_owner_public_key(String::from("Plz dont use dis"));
+
+    transfer
+}

--- a/common/src/addressing.rs
+++ b/common/src/addressing.rs
@@ -4,14 +4,14 @@ use crypto::sha2::Sha256;
 pub const FAMILY_NAMESPACE: &str = "consensource";
 pub const FAMILY_VERSION: &str = "0.1";
 const AGENT: &str = "00";
-const CERTIFICATE: &str = "01";
-const ORGANIZATION: &str = "02";
-const STANDARD: &str = "03";
+pub const CERTIFICATE: &str = "01";
+pub const ORGANIZATION: &str = "02";
+pub const STANDARD: &str = "03";
 const REQUEST: &str = "04";
 const ASSERTION: &str = "05";
 
 const PREFIX_SIZE: usize = 6;
-const RESERVED_SPACE: &str = "00";
+pub const RESERVED_SPACE: &str = "00";
 
 fn hash(object: &str, num: usize) -> String {
     let mut sha = Sha256::new();

--- a/common/src/batch.rs
+++ b/common/src/batch.rs
@@ -1,0 +1,246 @@
+use error::ConsenSourceError;
+use protobuf::{Message, RepeatedField};
+use sawtooth_sdk::messages::batch::{Batch, BatchHeader, BatchList};
+use sawtooth_sdk::messages::transaction::Transaction;
+use sawtooth_sdk::signing::Signer;
+
+pub trait ToBatch {
+    /// Returns a Batch for the given Transaction and Signer
+    ///
+    /// # Arguments
+    ///
+    /// * `signer` - the signer to be used to sign the transaction
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs during serialization of the provided Transaction or
+    /// internally created `BatchHeader`, a `ConsenSourceError::ProtobufError` is
+    /// returned.
+    ///
+    /// If a signing error occurs, a `ConsenSourceError::SigningError` is returned.
+    fn to_batch(&self, signer: &Signer) -> Result<Batch, ConsenSourceError>;
+    /// Returns a BatchList containing the provided Batch
+    ///
+    /// # Arguments
+    ///
+    /// * `signer` - the signer to be used to sign the transaction
+    fn to_batch_list(&self, signer: &Signer) -> Result<BatchList, ConsenSourceError> {
+        let mut batch_list = BatchList::new();
+        batch_list.set_batches(RepeatedField::from_vec(vec![self.to_batch(signer)?]));
+        Ok(batch_list)
+    }
+}
+
+impl ToBatch for Transaction {
+    fn to_batch(&self, signer: &Signer) -> Result<Batch, ConsenSourceError> {
+        let mut batch = Batch::new();
+        let mut batch_header = BatchHeader::new();
+
+        batch_header
+            .set_transaction_ids(RepeatedField::from_vec(vec![self.header_signature.clone()]));
+        batch_header.set_signer_public_key(signer.get_public_key()?.as_hex());
+        batch.set_transactions(RepeatedField::from_vec(vec![self.to_owned()]));
+
+        let batch_header_bytes = batch_header.write_to_bytes()?;
+        batch.set_header(batch_header_bytes.clone());
+
+        let b: &[u8] = &batch_header_bytes;
+        batch.set_header_signature(signer.sign(b)?);
+
+        Ok(batch)
+    }
+}
+impl ToBatch for Vec<Transaction> {
+    fn to_batch(&self, signer: &Signer) -> Result<Batch, ConsenSourceError> {
+        let mut batch = Batch::new();
+        let mut batch_header = BatchHeader::new();
+        batch_header.set_transaction_ids(RepeatedField::from_vec(
+            self.iter()
+                .map(|txn| txn.header_signature.clone())
+                .collect(),
+        ));
+        batch_header.set_signer_public_key(signer.get_public_key()?.as_hex());
+        batch.set_transactions(RepeatedField::from_ref(self));
+
+        let batch_header_bytes = batch_header.write_to_bytes()?;
+        batch.set_header(batch_header_bytes.clone());
+
+        let b: &[u8] = &batch_header_bytes;
+        batch.set_header_signature(signer.sign(b)?);
+
+        Ok(batch)
+    }
+}
+
+// Unit tests
+#[cfg(test)]
+mod tests {
+    use crate::action::create_agent;
+    use crate::prelude::*;
+    use sawtooth_sdk::signing;
+    use sawtooth_sdk::signing::CryptoFactory;
+    const AGENT_NAME: &str = "test_agent";
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn create_batch_test() {
+        // Create test signer
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let start = SystemTime::now();
+        let since_the_epoch = start
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+        let ms_since_epoch = since_the_epoch.as_secs();
+
+        let test_txn = create_agent(AGENT_NAME, ms_since_epoch)
+            .make_transaction_without_org(&signer)
+            .expect("Failed to create transaction");
+
+        let test_batch = test_txn.to_batch(&signer);
+
+        assert!(test_batch.is_ok());
+
+        assert_eq!(
+            test_batch.unwrap().get_transactions().get(0),
+            Some(&test_txn)
+        );
+    }
+
+    #[test]
+    fn create_batch_with_transactions_test() {
+        // Create test signer
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let start = SystemTime::now();
+        let since_the_epoch = start
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+        let ms_since_epoch = since_the_epoch.as_secs();
+
+        let test_txn_1 = create_agent(AGENT_NAME, ms_since_epoch)
+            .make_transaction_without_org(&signer)
+            .expect("Failed to create transaction");
+
+        let test_txn_2 = create_agent(AGENT_NAME, ms_since_epoch)
+            .make_transaction_without_org(&signer)
+            .expect("Failed to create transaction");
+
+        let test_batch = vec![test_txn_1.clone(), test_txn_2.clone()].to_batch(&signer);
+
+        assert!(test_batch.is_ok());
+
+        let unwrapped_test_batch = test_batch.unwrap();
+
+        assert_eq!(
+            unwrapped_test_batch.get_transactions().get(0),
+            Some(&test_txn_1)
+        );
+
+        assert_eq!(
+            unwrapped_test_batch.get_transactions().get(1),
+            Some(&test_txn_2)
+        );
+    }
+
+    #[test]
+    fn create_batch_list_test() {
+        // Create test signer
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let start = SystemTime::now();
+        let since_the_epoch = start
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+        let ms_since_epoch = since_the_epoch.as_secs();
+
+        let test_txn = create_agent(AGENT_NAME, ms_since_epoch)
+            .make_transaction_without_org(&signer)
+            .expect("Failed to create transaction");
+
+        let batch_list = test_txn.to_batch_list(&signer);
+
+        assert!(batch_list.is_ok());
+
+        let unwrapped_batch_list = batch_list.unwrap();
+
+        assert!(unwrapped_batch_list.get_batches().len() == 1);
+
+        assert_eq!(
+            unwrapped_batch_list.get_batches().get(0),
+            Some(&test_txn.to_batch(&signer).unwrap())
+        );
+    }
+
+    #[test]
+    fn create_batch_list_with_transactions_test() {
+        // Create test signer
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let start = SystemTime::now();
+        let since_the_epoch = start
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+        let ms_since_epoch = since_the_epoch.as_secs();
+
+        let test_txn_1 = create_agent(AGENT_NAME, ms_since_epoch)
+            .make_transaction_without_org(&signer)
+            .expect("Failed to create transaction");
+
+        let test_txn_2 = create_agent(AGENT_NAME, ms_since_epoch)
+            .make_transaction_without_org(&signer)
+            .expect("Failed to create transaction");
+
+        let batch_list = vec![test_txn_1.clone(), test_txn_2.clone()].to_batch_list(&signer);
+
+        assert!(batch_list.is_ok());
+
+        let unwrapped_batch_list = batch_list.unwrap();
+
+        assert!(unwrapped_batch_list.get_batches().len() == 1);
+
+        assert_eq!(
+            unwrapped_batch_list
+                .get_batches()
+                .get(0)
+                .unwrap()
+                .get_transactions()
+                .get(0),
+            Some(&test_txn_1)
+        );
+
+        assert_eq!(
+            unwrapped_batch_list
+                .get_batches()
+                .get(0)
+                .unwrap()
+                .get_transactions()
+                .get(1),
+            Some(&test_txn_2)
+        );
+    }
+}

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -1,0 +1,81 @@
+// Copyright 2018 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains functions which assist with error management
+
+use sawtooth_sdk::signing;
+use std::borrow::Borrow;
+use std::error::Error as StdError;
+
+#[derive(Debug)]
+pub enum ConsenSourceError {
+    /// The user has provided invalid inputs; the string by this error
+    /// is appropriate for display to the user without additional context
+    UserError(String),
+    IoError(std::io::Error),
+    SigningError(signing::Error),
+    ProtobufError(protobuf::ProtobufError),
+    InvalidTransactionError(String),
+    InvalidInputError(String),
+}
+
+impl StdError for ConsenSourceError {
+    fn cause(&self) -> Option<&dyn StdError> {
+        match *self {
+            ConsenSourceError::UserError(ref _s) => None,
+            ConsenSourceError::IoError(ref err) => Some(err.borrow()),
+            ConsenSourceError::SigningError(ref err) => Some(err.borrow()),
+            ConsenSourceError::ProtobufError(ref err) => Some(err.borrow()),
+            ConsenSourceError::InvalidTransactionError(ref _s) => None,
+            ConsenSourceError::InvalidInputError(ref _s) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for ConsenSourceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            ConsenSourceError::UserError(ref s) => write!(f, "Error: {}", s),
+            ConsenSourceError::IoError(ref err) => write!(f, "IoError: {}", err),
+            ConsenSourceError::SigningError(ref err) => {
+                write!(f, "SigningError: {}", err.to_string())
+            }
+            ConsenSourceError::ProtobufError(ref err) => {
+                write!(f, "ProtobufError: {}", err.to_string())
+            }
+            ConsenSourceError::InvalidTransactionError(ref s) => {
+                write!(f, "InvalidTransactionError: {}", s)
+            }
+            ConsenSourceError::InvalidInputError(ref s) => write!(f, "InvalidInput: {}", s),
+        }
+    }
+}
+
+impl From<std::io::Error> for ConsenSourceError {
+    fn from(e: std::io::Error) -> Self {
+        ConsenSourceError::IoError(e)
+    }
+}
+
+impl From<protobuf::ProtobufError> for ConsenSourceError {
+    fn from(e: protobuf::ProtobufError) -> Self {
+        ConsenSourceError::ProtobufError(e)
+    }
+}
+
+impl From<signing::Error> for ConsenSourceError {
+    fn from(e: signing::Error) -> Self {
+        ConsenSourceError::SigningError(e)
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,7 +1,366 @@
 extern crate crypto;
 extern crate protobuf;
+extern crate sawtooth_sdk;
 
 include!("../build/gen_source.rs");
 
 // exported modules
+pub mod action;
 pub mod addressing;
+pub mod batch;
+pub mod error;
+pub mod transaction;
+
+pub mod prelude {
+    pub use batch::ToBatch;
+    pub use error::ConsenSourceError;
+    pub use transaction::Transact;
+}
+
+pub use crate::prelude::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use action;
+    use proto::organization::{Organization_Authorization_Role, Organization_Type};
+    use proto::request::Request_Status;
+    use sawtooth_sdk::signing;
+    use sawtooth_sdk::signing::CryptoFactory;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    const PUBLIC_KEY: &str = "02b018d38f052973b21235893c2d08b705269255d9bfb326ee63eb6c5841075882";
+    const AGENT_NAME: &str = "test_agent";
+    const ORG_ID_1: &str = "test_org_id_1";
+    const ORG_ID_2: &str = "test_org_id_2";
+    const ORG_NAME: &str = "test_org_name";
+    const CONTACT_NAME: &str = "test_contact_name";
+    const CONTACT_PHONE: &str = "test_contact_phone";
+    const CONTACT_LANG: &str = "test_lang";
+    const STREET: &str = "test_street";
+    const CITY: &str = "test_city";
+    const COUNTRY: &str = "test_country";
+    const CERT_ID: &str = "test_cert_id";
+    const REQUEST_ID: &str = "test_request_id";
+    const STANDARD_ID: &str = "test_standard_id";
+    const STANDARD_NAME: &str = "test_standard_name";
+    const STANDARD_VERSION: &str = "test_standard_version";
+    const STANDARD_DESCRIPTION: &str = "test_standard_desc";
+    const STANDARD_LINK: &str = "test_standard_link";
+    const ASSERTION_ID: &str = "test_assertion_id";
+
+    #[test]
+    fn create_agent_to_transaction() {
+        let start = SystemTime::now();
+        let since_the_epoch = start
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+        let ms_since_epoch = since_the_epoch.as_secs();
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let action = action::create_agent(AGENT_NAME, ms_since_epoch);
+
+        let transaction = action.make_transaction_without_org(&signer);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn create_org_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let action = action::create_organization(
+            ORG_ID_1,
+            ORG_NAME,
+            Organization_Type::FACTORY,
+            CONTACT_NAME,
+            CONTACT_PHONE,
+            CONTACT_LANG,
+            Some(STREET),
+            Some(CITY),
+            Some(COUNTRY),
+        );
+
+        let transaction = action.make_transaction_without_org(&signer);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn update_org_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let action = action::update_organization(
+            ORG_ID_1,
+            Some(ORG_NAME),
+            Some(CONTACT_NAME),
+            Some(CONTACT_PHONE),
+            Some(CONTACT_LANG),
+            Some(STREET),
+            Some(CITY),
+            Some(COUNTRY),
+        );
+
+        let transaction = action.make_transaction_without_org(&signer);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn auth_agent_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let action =
+            action::authorize_agent(PUBLIC_KEY, Organization_Authorization_Role::TRANSACTOR);
+
+        let transaction = action.make_transaction(&signer, ORG_ID_1);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn issue_certificate_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let action =
+            action::issue_certificate(CERT_ID, ORG_ID_1, None, STANDARD_ID, vec![], "1", "2");
+
+        let transaction = action.make_transaction(&signer, ORG_ID_2);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn update_certificate_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let action = action::update_certificate(CERT_ID, vec![], "1", "2");
+
+        let transaction = action.make_transaction(&signer, ORG_ID_1);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn create_standard_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let action = action::create_standard(
+            STANDARD_NAME,
+            STANDARD_VERSION,
+            STANDARD_DESCRIPTION,
+            STANDARD_LINK,
+            1,
+        );
+
+        let transaction = action.make_transaction(&signer, ORG_ID_1);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn update_standard_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let action = action::update_standard(
+            STANDARD_NAME,
+            STANDARD_VERSION,
+            STANDARD_DESCRIPTION,
+            STANDARD_LINK,
+            1,
+        );
+
+        let transaction = action.make_transaction(&signer, ORG_ID_1);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn create_accreditation_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let action = action::create_accreditation(STANDARD_ID, ORG_ID_1, 1, 2);
+
+        let transaction = action.make_transaction(&signer, ORG_ID_2);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn open_request_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let action = action::open_request(REQUEST_ID, STANDARD_ID, 1);
+
+        let transaction = action.make_transaction(&signer, ORG_ID_1);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn change_request_status_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let action = action::change_request_status(REQUEST_ID, Request_Status::IN_PROGRESS);
+
+        let transaction = action.make_transaction(&signer, ORG_ID_1);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn create_factory_assertion_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let create_org = action::create_organization(
+            ORG_ID_1,
+            ORG_NAME,
+            Organization_Type::FACTORY,
+            CONTACT_NAME,
+            CONTACT_PHONE,
+            CONTACT_LANG,
+            Some(STREET),
+            Some(CITY),
+            Some(COUNTRY),
+        );
+
+        let action = action::create_factory_assertion(ASSERTION_ID, create_org);
+
+        let transaction = action.make_transaction(&signer, ORG_ID_2);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn create_standard_assertion_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let create_standard = action::create_standard(
+            STANDARD_NAME,
+            STANDARD_VERSION,
+            STANDARD_DESCRIPTION,
+            STANDARD_LINK,
+            1,
+        );
+
+        let action = action::create_standard_assertion(ASSERTION_ID, create_standard);
+
+        let transaction = action.make_transaction(&signer, ORG_ID_1);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn create_certificate_assertion_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let create_cert =
+            action::issue_certificate(CERT_ID, ORG_ID_1, None, STANDARD_ID, vec![], "1", "2");
+
+        let action = action::create_certificate_assertion(ASSERTION_ID, create_cert);
+
+        let transaction = action.make_transaction(&signer, ORG_ID_2);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
+    fn transfer_assertion_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let action = action::transfer_assertion(ASSERTION_ID);
+
+        let transaction = action.make_transaction_without_org(&signer);
+
+        assert!(transaction.is_ok())
+    }
+}

--- a/common/src/transaction.rs
+++ b/common/src/transaction.rs
@@ -1,0 +1,468 @@
+use addressing;
+use addressing::{CERTIFICATE, ORGANIZATION, RESERVED_SPACE, STANDARD};
+use crypto::digest::Digest;
+use crypto::sha2::Sha512;
+use error::ConsenSourceError;
+use proto::payload;
+use proto::payload::CertificateRegistryPayload_Action;
+use protobuf::{Message, RepeatedField};
+use sawtooth_sdk::messages::transaction::{Transaction, TransactionHeader};
+use sawtooth_sdk::signing::Signer;
+use std::time::Instant;
+
+/// Creates a nonce appropriate for a TransactionHeader
+fn create_nonce() -> String {
+    let elapsed = Instant::now().elapsed();
+    format!("{}{}", elapsed.as_secs(), elapsed.subsec_nanos())
+}
+
+/// Returns a hex string representation of the supplied bytes
+///
+/// # Arguments
+///
+/// * `b` - input bytes
+fn bytes_to_hex_str(b: &[u8]) -> String {
+    b.iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+pub trait Transact: Message {
+    /// Wraps the action in a payload Protobuf type
+    ///
+    /// Sets the payload action enum and the associated action field
+    fn make_payload(&self) -> payload::CertificateRegistryPayload;
+    /// Returns a Vec of addresses this transaction needs to read from
+    /// without considering the agent's org
+    ///
+    /// # Arguments
+    ///
+    /// * `public_key` - the public key of the signer to be used to sign the transaction
+    fn inputs_without_org(&self, public_key: String) -> Vec<String>;
+    /// Returns a Vec of addresses this transaction needs to write to
+    /// without considering the agent's org
+    ///
+    /// # Arguments
+    ///
+    /// * `public_key` - the public key of the signer to be used to sign the transaction
+    fn outputs_without_org(&self, public_key: String) -> Vec<String>;
+    /// Returns a Transaction Result for this action type
+    /// without considering the agent's org for inputs/outputs
+    ///
+    /// # Arguments
+    ///
+    /// * `signer` - the signer to be used to sign the transaction
+    /// * `org_id` - the organization id of the signer's agent
+    fn make_transaction_without_org(
+        &self,
+        signer: &Signer,
+    ) -> Result<Transaction, ConsenSourceError> {
+        let payload = self.make_payload();
+        let mut txn = Transaction::new();
+        let mut txn_header = TransactionHeader::new();
+
+        txn_header.set_family_name(String::from(addressing::FAMILY_NAMESPACE));
+        txn_header.set_family_version(String::from(addressing::FAMILY_VERSION));
+        txn_header.set_nonce(create_nonce());
+        txn_header.set_signer_public_key(signer.get_public_key()?.as_hex());
+        txn_header.set_batcher_public_key(signer.get_public_key()?.as_hex());
+
+        txn_header.set_inputs(RepeatedField::from_vec(
+            self.inputs_without_org(signer.get_public_key()?.as_hex()),
+        ));
+        txn_header.set_outputs(RepeatedField::from_vec(
+            self.outputs_without_org(signer.get_public_key()?.as_hex()),
+        ));
+
+        let payload_bytes = payload.write_to_bytes()?;
+        let mut sha = Sha512::new();
+        sha.input(&payload_bytes);
+        let hash: &mut [u8] = &mut [0; 64];
+        sha.result(hash);
+        txn_header.set_payload_sha512(bytes_to_hex_str(hash));
+        txn.set_payload(payload_bytes);
+
+        let txn_header_bytes = txn_header.write_to_bytes()?;
+        txn.set_header(txn_header_bytes.clone());
+
+        let b: &[u8] = &txn_header_bytes;
+        txn.set_header_signature(signer.sign(b)?);
+
+        Ok(txn)
+    }
+    /// Returns a Vec of addresses this transaction needs to read from
+    ///
+    /// # Arguments
+    ///
+    /// * `public_key` - the public key of the signer to be used to sign the transaction
+    /// * `org_id` - the organization id of the signer's agent
+    fn inputs(&self, public_key: String, org_id: String) -> Vec<String> {
+        let mut inputs = self.inputs_without_org(public_key);
+        if let Some(org_id) = org_id.into() {
+            inputs.push(addressing::make_organization_address(&org_id));
+        }
+        inputs
+    }
+    /// Returns a Vec of addresses this transaction needs to write to
+    ///
+    /// # Arguments
+    ///
+    /// * `public_key` - the public key of the signer to be used to sign the transaction
+    /// * `org_id` - the organization id of the signer's agent
+    fn outputs(&self, public_key: String, _org_id: String) -> Vec<String> {
+        self.outputs_without_org(public_key)
+    }
+    /// Returns a Transaction Result for this action type
+    ///
+    /// # Arguments
+    ///
+    /// * `signer` - the signer to be used to sign the transaction
+    /// * `org_id` - the organization id of the signer's agent
+    fn make_transaction(
+        &self,
+        signer: &Signer,
+        org_id: &str,
+    ) -> Result<Transaction, ConsenSourceError> {
+        let payload = self.make_payload();
+        let mut txn = Transaction::new();
+        let mut txn_header = TransactionHeader::new();
+
+        txn_header.set_family_name(String::from(addressing::FAMILY_NAMESPACE));
+        txn_header.set_family_version(String::from(addressing::FAMILY_VERSION));
+        txn_header.set_nonce(create_nonce());
+        txn_header.set_signer_public_key(signer.get_public_key()?.as_hex());
+        txn_header.set_batcher_public_key(signer.get_public_key()?.as_hex());
+
+        txn_header.set_inputs(RepeatedField::from_vec(
+            self.inputs(signer.get_public_key()?.as_hex(), org_id.to_string()),
+        ));
+        txn_header.set_outputs(RepeatedField::from_vec(
+            self.outputs(signer.get_public_key()?.as_hex(), org_id.to_string()),
+        ));
+
+        let payload_bytes = payload.write_to_bytes()?;
+        let mut sha = Sha512::new();
+        sha.input(&payload_bytes);
+        let hash: &mut [u8] = &mut [0; 64];
+        sha.result(hash);
+        txn_header.set_payload_sha512(bytes_to_hex_str(hash));
+        txn.set_payload(payload_bytes);
+
+        let txn_header_bytes = txn_header.write_to_bytes()?;
+        txn.set_header(txn_header_bytes.clone());
+
+        let b: &[u8] = &txn_header_bytes;
+        txn.set_header_signature(signer.sign(b)?);
+
+        Ok(txn)
+    }
+}
+
+impl Transact for payload::CreateAgentAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        vec![agent_address]
+    }
+    fn outputs_without_org(&self, public_key: String) -> Vec<String> {
+        self.inputs_without_org(public_key)
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::CREATE_AGENT;
+        payload.set_create_agent(self.clone());
+        payload
+    }
+}
+
+impl Transact for payload::CreateOrganizationAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        let org_address = addressing::make_organization_address(&self.id);
+        vec![agent_address, org_address]
+    }
+    fn outputs_without_org(&self, public_key: String) -> Vec<String> {
+        self.inputs_without_org(public_key)
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::CREATE_ORGANIZATION;
+        payload.set_create_organization(self.clone());
+        payload
+    }
+}
+
+impl Transact for payload::UpdateOrganizationAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        let org_address = addressing::make_organization_address(&self.id);
+        vec![agent_address, org_address]
+    }
+    fn outputs_without_org(&self, public_key: String) -> Vec<String> {
+        self.inputs_without_org(public_key)
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::UPDATE_ORGANIZATION;
+        payload.set_update_organization(self.clone());
+        payload
+    }
+}
+
+/// Needs to called with org_id
+impl Transact for payload::AuthorizeAgentAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let authorizer_agent_address = addressing::make_agent_address(&public_key);
+        let target_agent_address = addressing::make_agent_address(&self.public_key);
+        vec![authorizer_agent_address, target_agent_address]
+    }
+    fn outputs_without_org(&self, _public_key: String) -> Vec<String> {
+        let target_agent_address = addressing::make_agent_address(&self.public_key);
+        vec![target_agent_address]
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::AUTHORIZE_AGENT;
+        payload.set_authorize_agent(self.clone());
+        payload
+    }
+    fn outputs(&self, public_key: String, org_id: String) -> Vec<String> {
+        let mut outputs = self.outputs_without_org(public_key);
+        if let Some(org_id) = org_id.into() {
+            outputs.push(addressing::make_organization_address(&org_id));
+        }
+        outputs
+    }
+}
+
+/// Needs to called with org_id
+impl Transact for payload::IssueCertificateAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        let cert_address = addressing::make_certificate_address(&self.id);
+        let factory_address = addressing::make_organization_address(&self.factory_id);
+        vec![agent_address, cert_address, factory_address]
+    }
+    fn outputs_without_org(&self, _public_key: String) -> Vec<String> {
+        let cert_address = addressing::make_certificate_address(&self.id);
+        vec![cert_address]
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::ISSUE_CERTIFICATE;
+        payload.set_issue_certificate(self.clone());
+        payload
+    }
+}
+
+/// Needs to called with org_id
+impl Transact for payload::CreateStandardAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        let standard_address = addressing::make_standard_address(&self.standard_id);
+        vec![agent_address, standard_address]
+    }
+    fn outputs_without_org(&self, _public_key: String) -> Vec<String> {
+        let standard_address = addressing::make_standard_address(&self.standard_id);
+        vec![standard_address]
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::CREATE_STANDARD;
+        payload.set_create_standard(self.clone());
+        payload
+    }
+}
+
+/// Needs to called with org_id
+impl Transact for payload::UpdateStandardAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        let standard_address = addressing::make_standard_address(&self.standard_id);
+        vec![agent_address, standard_address]
+    }
+    fn outputs_without_org(&self, _public_key: String) -> Vec<String> {
+        let standard_address = addressing::make_standard_address(&self.standard_id);
+        vec![standard_address]
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::UPDATE_STANDARD;
+        payload.set_update_standard(self.clone());
+        payload
+    }
+}
+
+/// Needs to called with org_id
+impl Transact for payload::AccreditCertifyingBodyAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        let standard_address = addressing::make_standard_address(&self.standard_id);
+        let certifying_body_address =
+            addressing::make_organization_address(&self.certifying_body_id);
+        vec![agent_address, standard_address, certifying_body_address]
+    }
+    fn outputs_without_org(&self, _public_key: String) -> Vec<String> {
+        let certifying_body_address =
+            addressing::make_organization_address(&self.certifying_body_id);
+        vec![certifying_body_address]
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::ACCREDIT_CERTIFYING_BODY_ACTION;
+        payload.set_accredit_certifying_body_action(self.clone());
+        payload
+    }
+}
+
+/// Needs to called with org_id
+impl Transact for payload::OpenRequestAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        let request_address = addressing::make_request_address(&self.id);
+        let standard_address = addressing::make_standard_address(&self.standard_id);
+        vec![agent_address, request_address, standard_address]
+    }
+    fn outputs_without_org(&self, _public_key: String) -> Vec<String> {
+        let request_address = addressing::make_request_address(&self.id);
+        vec![request_address]
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::OPEN_REQUEST_ACTION;
+        payload.set_open_request_action(self.clone());
+        payload
+    }
+}
+
+/// Needs to called with org_id
+impl Transact for payload::ChangeRequestStatusAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        let request_address = addressing::make_request_address(&self.request_id);
+        vec![agent_address, request_address]
+    }
+    fn outputs_without_org(&self, _public_key: String) -> Vec<String> {
+        let request_address = addressing::make_request_address(&self.request_id);
+        vec![request_address]
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::CHANGE_REQUEST_STATUS_ACTION;
+        payload.set_change_request_status_action(self.clone());
+        payload
+    }
+}
+
+/// Needs to called with org_id
+impl Transact for payload::AssertAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        let assertion_address = addressing::make_assertion_address(&self.assertion_id);
+        if self.has_new_factory() {
+            return vec![agent_address, assertion_address];
+        } else if self.has_new_certificate() {
+            let factory_address =
+                addressing::make_organization_address(self.get_new_certificate().get_factory_id());
+            let standard_address =
+                addressing::make_standard_address(self.get_new_certificate().get_standard_id());
+            return vec![
+                agent_address,
+                assertion_address,
+                factory_address,
+                standard_address,
+            ];
+        } else if self.has_new_standard() {
+            return vec![agent_address, assertion_address];
+        } else {
+            return vec![];
+        }
+    }
+    fn outputs_without_org(&self, _public_key: String) -> Vec<String> {
+        let assertion_address = addressing::make_assertion_address(&self.assertion_id);
+        if self.has_new_factory() {
+            let factory_address = addressing::make_organization_address(
+                self.get_new_factory().get_factory().get_id(),
+            );
+            return vec![assertion_address, factory_address];
+        } else if self.has_new_certificate() {
+            let cert_address =
+                addressing::make_certificate_address(self.get_new_certificate().get_id());
+            return vec![assertion_address, cert_address];
+        } else if self.has_new_standard() {
+            let standard_address =
+                addressing::make_standard_address(self.get_new_standard().get_standard_id());
+            return vec![assertion_address, standard_address];
+        } else {
+            return vec![];
+        }
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::ASSERT_ACTION;
+        payload.set_assert_action(self.clone());
+        payload
+    }
+}
+
+impl Transact for payload::TransferAssertionAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        let organization_space_prefix =
+            addressing::get_family_namespace_prefix() + RESERVED_SPACE + ORGANIZATION;
+        let certificate_space_prefix =
+            addressing::get_family_namespace_prefix() + RESERVED_SPACE + CERTIFICATE;
+        let standard_space_prefix =
+            addressing::get_family_namespace_prefix() + RESERVED_SPACE + STANDARD;
+        let assertion_address = addressing::make_assertion_address(&self.assertion_id);
+        vec![
+            agent_address,
+            organization_space_prefix,
+            certificate_space_prefix,
+            standard_space_prefix,
+            assertion_address,
+        ]
+    }
+    fn outputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        let organization_space_prefix =
+            addressing::get_family_namespace_prefix() + RESERVED_SPACE + ORGANIZATION;
+        let certificate_space_prefix =
+            addressing::get_family_namespace_prefix() + RESERVED_SPACE + CERTIFICATE;
+        let standard_space_prefix =
+            addressing::get_family_namespace_prefix() + RESERVED_SPACE + STANDARD;
+        let assertion_address = addressing::make_assertion_address(&self.assertion_id);
+        vec![
+            agent_address,
+            organization_space_prefix,
+            certificate_space_prefix,
+            standard_space_prefix,
+            assertion_address,
+        ]
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::TRANSFER_ASSERTION;
+        payload.set_transfer_assertion_action(self.clone());
+        payload
+    }
+}
+
+/// Needs to called with org_id
+impl Transact for payload::UpdateCertificateAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        let cert_address = addressing::make_certificate_address(&self.id);
+        vec![agent_address, cert_address]
+    }
+    fn outputs_without_org(&self, _public_key: String) -> Vec<String> {
+        let cert_address = addressing::make_certificate_address(&self.id);
+        vec![cert_address]
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::UPDATE_CERTIFICATE;
+        payload.set_update_certificate(self.clone());
+        payload
+    }
+}


### PR DESCRIPTION
## Proposed change/fix

- implements functions to create actions as `let action = create_agent(name, timestamp);`
- provides interface for `let txn = action.to_transaction(signer);`
- provides interface for `let batch = txn.to_batch(signer);`
- provides interface for `let batch_list = txn.to_batch_list(signer);`
- defines a prelude with `Transact` and `ToBatch` to be imported as `use common::prelude::*;`
- appropriates `CliError` as `ConsenSourceError` and exports in prelude
- Add unit tests for `Transact` and `ToBatch` traits

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test
`cargo clippy`
`cargo test`