### PR TITLE
feat: add request proto state enum

### DIFF
--- a/common/src/action.rs
+++ b/common/src/action.rs
@@ -212,6 +212,19 @@ pub fn open_request(
     request
 }
 
+pub fn create_pre_certified_request(
+    request_id: &str,
+    standard_id: &str,
+    request_date: u64,
+) -> payload::CreatePreCertifiedRequestAction {
+    let mut request = payload::CreatePreCertifiedRequestAction::new();
+    request.set_id(String::from(request_id));
+    request.set_standard_id(String::from(standard_id));
+    request.set_request_date(request_date);
+
+    request
+}
+
 pub fn change_request_status(
     request_id: &str,
     status: Request_Status,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -257,6 +257,23 @@ mod tests {
     }
 
     #[test]
+    fn create_pre_certified_request_to_transaction() {
+        let context =
+            signing::create_context("secp256k1").expect("Failed to create secp256k1 context");
+        let private_key = context
+            .new_random_private_key()
+            .expect("Failed to generate random private key");
+        let factory = CryptoFactory::new(&*context);
+        let signer = factory.new_signer(&*private_key);
+
+        let action = action::create_pre_certified_request(REQUEST_ID, STANDARD_ID, 1);
+
+        let transaction = action.make_transaction(&signer, ORG_ID_1);
+
+        assert!(transaction.is_ok())
+    }
+
+    #[test]
     fn change_request_status_to_transaction() {
         let context =
             signing::create_context("secp256k1").expect("Failed to create secp256k1 context");

--- a/common/src/transaction.rs
+++ b/common/src/transaction.rs
@@ -336,6 +336,26 @@ impl Transact for payload::OpenRequestAction {
 }
 
 /// Needs to called with org_id
+impl Transact for payload::CreatePreCertifiedRequestAction {
+    fn inputs_without_org(&self, public_key: String) -> Vec<String> {
+        let agent_address = addressing::make_agent_address(&public_key);
+        let request_address = addressing::make_request_address(&self.id);
+        let standard_address = addressing::make_standard_address(&self.standard_id);
+        vec![agent_address, request_address, standard_address]
+    }
+    fn outputs_without_org(&self, _public_key: String) -> Vec<String> {
+        let request_address = addressing::make_request_address(&self.id);
+        vec![request_address]
+    }
+    fn make_payload(&self) -> payload::CertificateRegistryPayload {
+        let mut payload = payload::CertificateRegistryPayload::new();
+        payload.action = CertificateRegistryPayload_Action::CREATE_PRE_CERTIFIED_REQUEST_ACTION;
+        payload.set_create_pre_certified_request_action(self.clone());
+        payload
+    }
+}
+
+/// Needs to called with org_id
 impl Transact for payload::ChangeRequestStatusAction {
     fn inputs_without_org(&self, public_key: String) -> Vec<String> {
         let agent_address = addressing::make_agent_address(&public_key);

--- a/protos/payload.proto
+++ b/protos/payload.proto
@@ -21,6 +21,7 @@ message CertificateRegistryPayload{
         ASSERT_ACTION = 11;
         TRANSFER_ASSERTION = 12;
         UPDATE_CERTIFICATE = 13;
+        CREATE_PRE_CERTIFIED_REQUEST_ACTION = 14;
     }
 
     // Whether the payload contains a create agent, create organization,
@@ -42,6 +43,7 @@ message CertificateRegistryPayload{
     AssertAction assert_action = 12;
     TransferAssertionAction transfer_assertion_action = 13;
     UpdateCertificateAction update_certificate = 14;
+    CreatePreCertifiedRequestAction create_pre_certified_request_action = 15;
 }
 
 message CreateAgentAction {
@@ -250,4 +252,16 @@ message TransferAssertionAction {
     string assertion_id = 1;
     // public key of the new owner
     string new_owner_public_key = 2;
+}
+
+message CreatePreCertifiedRequestAction {
+    // UUID of the request.
+    string id = 1;
+
+    // Standard the factory is claiming they are pre certified to
+    string standard_id = 2;
+
+    // Time request was made
+    // Format: UTC timestamp
+    uint64 request_date = 3;
 }

--- a/protos/request.proto
+++ b/protos/request.proto
@@ -7,6 +7,7 @@ message Request {
         IN_PROGRESS = 2;
         CLOSED = 3;
         CERTIFIED = 4;
+        PRE_CERTIFIED = 5;
     }
 
     // UUID of this request.


### PR DESCRIPTION
Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>

## Proposed change/fix

- Adds a `PRE_CERTIFIED` value to the `Status` enum for the `Request` proto.
- Adds a `CreatePreCertifiedRequestAction` to the payload protos

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

`cargo test`